### PR TITLE
Implemented functionality to toggle Login and Signup screens

### DIFF
--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import { Text, View } from 'react-native'
+import { connect } from "react-redux"
+import Login from "../views/Login"
+import Signup from "../views/Signup"
+
+interface Props {
+  showLogin: boolean
+}
+
+class Auth extends Component<Props> {
+  render() {
+    return (
+      <>
+        {this.props.showLogin ? <Login /> : <Signup />}
+      </>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    showLogin: state.showLogin
+  }
+}
+
+export default connect(mapStateToProps, null)(Auth)

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -36,4 +36,11 @@ const setUser = user => {
   return actionObj
 }
 
-export { setUserName, setActiveView, setUser };
+const toggleAuth = () => {
+  const actionObj = {
+    type: "TOGGLE_AUTH"
+  }
+  return actionObj
+}
+
+export { setUserName, setActiveView, setUser, toggleAuth };

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1,12 +1,13 @@
-import { setUserName, setActiveView, setUser } from '../actions/userActions'
+import { setUserName, setActiveView, setUser, toggleAuth } from '../actions/userActions'
 
 const initialState = {
   username: "",
   activeUsers: ["Mark", "Matt", "TJ", "Brittany"],
   activeEvents: ["Soccer", "Climbing", "Music", "Programming"],
   activeView: "meets",
+  showLogin: true,
   allUsers: [],
-  isLoggedIn: true,
+  isLoggedIn: false,
   user: {}
 }
 
@@ -35,6 +36,11 @@ const reducer = (state = initialState, action) => {
     case "SET_USER": {
       const copiedState = Object.assign({}, state)
       copiedState.user = Object.assign({}, action.user)
+      return copiedState
+    }
+    case "TOGGLE_AUTH": {
+      const copiedState = Object.assign({}, state)
+      copiedState.showLogin = !copiedState.showLogin
       return copiedState
     }
     default: {

--- a/views/Login.tsx
+++ b/views/Login.tsx
@@ -34,7 +34,8 @@ interface ServerResponse {
 }
 
 interface Props {
-  setUser: Function
+  setUser: Function,
+  toggleAuth: Function
 }
 
 class Login extends Component<Props, State> {
@@ -82,6 +83,7 @@ class Login extends Component<Props, State> {
         <TouchableOpacity onPress={this.handleLogin} style={styles.login__button}>
           <Text style={styles.login__button__text}>Login</Text>
         </TouchableOpacity>
+        <Text style={styles.login__signup} onPress={this.props.toggleAuth}>Sign Up</Text>
       </ImageBackground>
     )
   }
@@ -124,6 +126,12 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontWeight: "bold",
     fontSize: 18
+  },
+  login__signup: {
+    color: "#fff",
+    position: "relative",
+    top: 50,
+    fontSize: 16
   }
 })
 
@@ -133,6 +141,11 @@ const mapDispatchToProps = dispatch => {
       dispatch({
         type: "SET_USER",
         user
+      })
+    },
+    toggleAuth: () => {
+      dispatch({
+        type: "TOGGLE_AUTH",
       })
     }
   }

--- a/views/Signup.tsx
+++ b/views/Signup.tsx
@@ -40,7 +40,8 @@ interface Error {
 }
 
 interface Props {
-  setUser: Function
+  setUser: Function,
+  toggleAuth: Function
 }
 
 class Signup extends Component<Props, State> {
@@ -100,6 +101,7 @@ class Signup extends Component<Props, State> {
         <TouchableOpacity onPress={this.handleSignup} style={styles.signup__button}>
           <Text style={styles.signup__button__text}>Sign Up</Text>
         </TouchableOpacity>
+        <Text style={styles.signup__login} onPress={this.props.toggleAuth}>Login</Text>
       </ImageBackground>
     )
   }
@@ -141,6 +143,12 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontWeight: "bold",
     fontSize: 18
+  },
+  signup__login: {
+    color: "#fff",
+    position: "relative",
+    top: 30,
+    fontSize: 16
   }
 })
 
@@ -150,6 +158,11 @@ const mapDispatchToProps = dispatch => {
       dispatch({
         type: "SET_USER",
         user
+      })
+    },
+    toggleAuth: () => {
+      dispatch({
+        type: "TOGGLE_AUTH",
       })
     }
   }

--- a/views/Wrapper.tsx
+++ b/views/Wrapper.tsx
@@ -3,8 +3,7 @@ import { Text, View } from 'react-native'
 import { connect } from "react-redux"
 import Main from "./Main"
 import Navbar from "../components/Navbar"
-import Login from "./Login"
-import Signup from "./Signup"
+import Auth from "../components/Auth"
 
 interface Props {
   isLoggedIn: boolean
@@ -16,7 +15,7 @@ class Wrapper extends Component<Props> {
       <>
         {this.props.isLoggedIn ? <Main /> : null}
         {this.props.isLoggedIn ? <Navbar /> : null}
-        {!this.props.isLoggedIn ? <Signup /> : null}
+        {!this.props.isLoggedIn ? <Auth /> : null}
       </>
     )
   }


### PR DESCRIPTION
Created Auth component containing Signup and Login views, and conditionally render based on "showLogin" property in the Redux store.

Included Auth component in Wrapper to control whether to show the app or the Auth screens.

Adding "toggleAuth" action in  "userActions.js" and using that in the reducer to toggle "showLogin" boolean.

Adding "toggleAuth" dispatch in Login and Signup views to utilize the newly added action in "userActions.js